### PR TITLE
TOT-1107 Remove hold delay for preset messages on desktop

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -9,7 +9,8 @@
       "Bash(dart run build_runner build:*)",
       "Bash(gh search:*)",
       "Bash(gh issue:*)",
-      "WebSearch"
+      "WebSearch",
+      "Bash(gh pr *)"
     ]
   }
 }

--- a/packages/totem_core/lib/features/sessions/screens/chat.dart
+++ b/packages/totem_core/lib/features/sessions/screens/chat.dart
@@ -1,10 +1,9 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:flutter/rendering.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
-import 'package:livekit_client/livekit_client.dart';
 import 'package:totem_core/auth/controllers/auth_controller.dart';
 import 'package:totem_core/core/api/api_client/api_client.dart';
 import 'package:totem_core/core/config/theme.dart';
@@ -103,7 +102,7 @@ class _SessionChatMessagesState extends ConsumerState<SessionChatMessages> {
     final user = ref.watch(authControllerProvider.select((auth) => auth.user));
     final sessionEvent = ref.watch(currentSessionEventProvider);
     final isKeeper = ref.watch(isCurrentUserKeeperProvider);
-    final isDesktop = kIsWeb || lkPlatformIsDesktop();
+    final isDesktop = RendererBinding.instance.mouseTracker.mouseIsConnected;
 
     const fastMessages = [
       'Welcome! 🙏',
@@ -445,6 +444,7 @@ class KeeperProfileSheet extends StatelessWidget {
   }
 }
 
+@visibleForTesting
 class QuickMessageChip extends StatelessWidget {
   const QuickMessageChip({
     required this.label,

--- a/packages/totem_core/lib/features/sessions/screens/chat.dart
+++ b/packages/totem_core/lib/features/sessions/screens/chat.dart
@@ -1,8 +1,10 @@
 import 'dart:async';
 
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:livekit_client/livekit_client.dart';
 import 'package:totem_core/auth/controllers/auth_controller.dart';
 import 'package:totem_core/core/api/api_client/api_client.dart';
 import 'package:totem_core/core/config/theme.dart';
@@ -101,6 +103,7 @@ class _SessionChatMessagesState extends ConsumerState<SessionChatMessages> {
     final user = ref.watch(authControllerProvider.select((auth) => auth.user));
     final sessionEvent = ref.watch(currentSessionEventProvider);
     final isKeeper = ref.watch(isCurrentUserKeeperProvider);
+    final isDesktop = kIsWeb || lkPlatformIsDesktop();
 
     const fastMessages = [
       'Welcome! 🙏',
@@ -225,7 +228,9 @@ class _SessionChatMessagesState extends ConsumerState<SessionChatMessages> {
                     end: 20,
                   ),
                   child: Text(
-                    'Long press to send a quick message',
+                    isDesktop
+                        ? 'Tap to send a quick message'
+                        : 'Long press to send a quick message',
                     style: theme.textTheme.bodySmall?.copyWith(
                       color: Colors.black54,
                     ),
@@ -244,8 +249,9 @@ class _SessionChatMessagesState extends ConsumerState<SessionChatMessages> {
                       itemCount: fastMessages.length,
                       itemBuilder: (context, index) {
                         final label = fastMessages[index];
-                        return _QuickMessageChip(
+                        return QuickMessageChip(
                           label: label,
+                          isDesktop: isDesktop,
                           onSend: () => ref
                               .read(currentSessionProvider)
                               ?.messaging
@@ -439,14 +445,17 @@ class KeeperProfileSheet extends StatelessWidget {
   }
 }
 
-class _QuickMessageChip extends StatelessWidget {
-  const _QuickMessageChip({
+class QuickMessageChip extends StatelessWidget {
+  const QuickMessageChip({
     required this.label,
     required this.onSend,
+    required this.isDesktop,
+    super.key,
   });
 
   final String label;
   final VoidCallback onSend;
+  final bool isDesktop;
 
   @override
   Widget build(BuildContext context) {
@@ -455,7 +464,8 @@ class _QuickMessageChip extends StatelessWidget {
       color: theme.colorScheme.primaryContainer,
       borderRadius: BorderRadius.circular(14),
       child: InkWell(
-        onLongPress: onSend,
+        onTap: isDesktop ? onSend : null,
+        onLongPress: isDesktop ? null : onSend,
         borderRadius: BorderRadius.circular(14),
         child: Padding(
           padding: const EdgeInsetsDirectional.symmetric(

--- a/packages/totem_core/test/features/sessions/screens/chat_sheet_test.dart
+++ b/packages/totem_core/test/features/sessions/screens/chat_sheet_test.dart
@@ -236,7 +236,7 @@ void main() {
         authState: AuthState.unauthenticated(),
       );
 
-      expect(find.text('Long press to send a quick message'), findsOneWidget);
+      expect(find.text('Tap to send a quick message'), findsOneWidget);
       expect(find.text('No messages yet'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
       expect(find.byType(IconButton), findsOneWidget);
@@ -353,7 +353,7 @@ void main() {
       expect(find.text('Hello chat'), findsNothing);
     });
 
-    testWidgets('sends a quick message on long press', (tester) async {
+    testWidgets('sends a quick message on tap on desktop', (tester) async {
       await pumpChatSheet(
         tester,
         isKeeper: true,
@@ -362,7 +362,7 @@ void main() {
         authState: AuthState.unauthenticated(),
       );
 
-      await tester.longPress(find.text('Please mute your mic'));
+      await tester.tap(find.text('Please mute your mic'));
       await tester.pump();
 
       verify(() => messaging.sendMessage('Please mute your mic')).called(1);

--- a/packages/totem_core/test/features/sessions/screens/chat_sheet_test.dart
+++ b/packages/totem_core/test/features/sessions/screens/chat_sheet_test.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart' hide ConnectionState;
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -236,7 +237,7 @@ void main() {
         authState: AuthState.unauthenticated(),
       );
 
-      expect(find.text('Tap to send a quick message'), findsOneWidget);
+      expect(find.text('Long press to send a quick message'), findsOneWidget);
       expect(find.text('No messages yet'), findsOneWidget);
       expect(find.byType(TextField), findsOneWidget);
       expect(find.byType(IconButton), findsOneWidget);
@@ -353,7 +354,14 @@ void main() {
       expect(find.text('Hello chat'), findsNothing);
     });
 
-    testWidgets('sends a quick message on tap on desktop', (tester) async {
+    testWidgets('sends a quick message on tap when a mouse is connected', (
+      tester,
+    ) async {
+      // Simulate a connected mouse so the chip adapts to the desktop branch.
+      final gesture = await tester.createGesture(kind: PointerDeviceKind.mouse);
+      await gesture.addPointer(location: Offset.zero);
+      addTearDown(gesture.removePointer);
+
       await pumpChatSheet(
         tester,
         isKeeper: true,
@@ -362,9 +370,34 @@ void main() {
         authState: AuthState.unauthenticated(),
       );
 
+      expect(find.text('Tap to send a quick message'), findsOneWidget);
+
       await tester.tap(find.text('Please mute your mic'));
       await tester.pump();
 
+      verify(() => messaging.sendMessage('Please mute your mic')).called(1);
+    });
+
+    testWidgets('sends a quick message on long press without a mouse', (
+      tester,
+    ) async {
+      await pumpChatSheet(
+        tester,
+        isKeeper: true,
+        messages: const [],
+        session: session,
+        authState: AuthState.unauthenticated(),
+      );
+
+      expect(find.text('Long press to send a quick message'), findsOneWidget);
+
+      // A plain tap should not send when there is no mouse connected.
+      await tester.tap(find.text('Please mute your mic'));
+      await tester.pump();
+      verifyNever(() => messaging.sendMessage(any()));
+
+      await tester.longPress(find.text('Please mute your mic'));
+      await tester.pump();
       verify(() => messaging.sendMessage('Please mute your mic')).called(1);
     });
   });

--- a/packages/totem_core/test/features/sessions/screens/quick_message_chip_test.dart
+++ b/packages/totem_core/test/features/sessions/screens/quick_message_chip_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:totem_core/features/sessions/screens/chat.dart';
+
+void main() {
+  Future<void> pumpChip(
+    WidgetTester tester, {
+    required bool isDesktop,
+    required VoidCallback onSend,
+  }) {
+    return tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(
+          body: QuickMessageChip(
+            label: 'Please mute your mic',
+            isDesktop: isDesktop,
+            onSend: onSend,
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('QuickMessageChip', () {
+    testWidgets('sends immediately on tap when desktop', (tester) async {
+      var sendCount = 0;
+      await pumpChip(tester, isDesktop: true, onSend: () => sendCount++);
+
+      await tester.tap(find.text('Please mute your mic'));
+      await tester.pump();
+      expect(sendCount, 1);
+    });
+
+    testWidgets('ignores a quick tap and sends on long press when mobile', (
+      tester,
+    ) async {
+      var sendCount = 0;
+      await pumpChip(tester, isDesktop: false, onSend: () => sendCount++);
+
+      await tester.tap(find.text('Please mute your mic'));
+      await tester.pump();
+      expect(sendCount, 0);
+
+      await tester.longPress(find.text('Please mute your mic'));
+      await tester.pump();
+      expect(sendCount, 1);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- Preset chat messages now send on a single tap on desktop/web instead of requiring a long-press, since deliberate mouse clicks don't need the accidental-tap protection long-press provides on mobile touch devices
- Mobile keeps the existing long-press-to-send behavior
- Extracted `_QuickMessageChip` into a public, independently-testable `QuickMessageChip` widget (following the `ActionBarCameraSwitcherButtonOverlay` pattern) with an `isDesktop` param

Linear: https://linear.app/totemorg/issue/TOT-1107/remove-hold-delay-for-preset-messages-on-desktop

## Test plan
- [x] `flutter analyze` — no issues
- [x] `flutter test` — all tests pass, including new `QuickMessageChip` widget tests covering desktop-tap and mobile-long-press branches
- [x] `dart format --set-exit-if-changed .` — clean