### PR TITLE
TOT-1082 Emoji reactions racing through animation with OS reduce-motion enabled

### DIFF
--- a/.github/actions/build-ios/action.yml
+++ b/.github/actions/build-ios/action.yml
@@ -85,6 +85,7 @@ runs:
       shell: bash
 
     - name: Build
-      run: ${{ inputs.build-cmd }}
+      # Wrapper retries transient Swift Package Manager download failures.
+      run: ${{ github.action_path }}/../../scripts/retry-flutter-build.sh ${{ inputs.build-cmd }}
       shell: bash
       working-directory: ${{ inputs.working-directory }}

--- a/.github/scripts/retry-flutter-build.sh
+++ b/.github/scripts/retry-flutter-build.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Runs a flutter build command, retrying only when it fails during Swift
+# Package Manager dependency resolution (transient network errors, e.g. the
+# grpc binary download from dl.google.com dropping mid-transfer). Any other
+# failure exits immediately so real build errors are not retried.
+set -uo pipefail
+
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+LOG="$(mktemp)"
+status=1
+
+for attempt in $(seq 1 "$MAX_ATTEMPTS"); do
+  if "$@" 2>&1 | tee "$LOG"; then
+    exit 0
+  fi
+  status=${PIPESTATUS[0]}
+  if ! grep -q "Could not resolve package dependencies" "$LOG"; then
+    exit "$status"
+  fi
+  echo "Swift package resolution failed (attempt $attempt/$MAX_ATTEMPTS); retrying in 15s..." >&2
+  sleep 15
+done
+
+echo "Swift package resolution still failing after $MAX_ATTEMPTS attempts." >&2
+exit "$status"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -99,4 +99,5 @@ jobs:
 
       - name: Build IPA
         working-directory: ./packages/totem_app
-        run: flutter build ipa --verbose --no-codesign --flavor ${{ matrix.flavor }}
+        # Wrapper retries transient Swift Package Manager download failures.
+        run: ../../.github/scripts/retry-flutter-build.sh flutter build ipa --verbose --no-codesign --flavor ${{ matrix.flavor }}

--- a/packages/totem_core/lib/features/sessions/widgets/emoji_bar.dart
+++ b/packages/totem_core/lib/features/sessions/widgets/emoji_bar.dart
@@ -317,7 +317,15 @@ class _RisingEmojiState extends State<RisingEmoji>
   @override
   void initState() {
     super.initState();
-    _controller = AnimationController(vsync: this, duration: widget.duration);
+    // Preserve the real duration when the OS "reduce motion" setting is on;
+    // otherwise the controller runs at 5% of its duration, which also cuts
+    // short the corner emoji on the participant card, whose visibility is
+    // tied to this animation completing.
+    _controller = AnimationController(
+      vsync: this,
+      duration: widget.duration,
+      animationBehavior: AnimationBehavior.preserve,
+    );
 
     _animation = Tween<double>(begin: 0, end: 1).animate(
       CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
@@ -359,6 +367,12 @@ class _RisingEmojiState extends State<RisingEmoji>
 
   @override
   Widget build(BuildContext context) {
+    // With "reduce motion" enabled, skip the float animation entirely. The
+    // controller still runs so onCompleted fires after the normal duration,
+    // keeping the corner emoji on the participant card visible as usual.
+    if (MediaQuery.disableAnimationsOf(context)) {
+      return const SizedBox.shrink();
+    }
     return AnimatedBuilder(
       animation: Listenable.merge([_animation, _opacityAnimation]),
       builder: (context, child) {


### PR DESCRIPTION
…nabled

With "reduce motion" enabled at the OS level, AnimationController runs at 5% of its duration, making the floating emoji shoot up instantly and cutting short the corner emoji on the participant card (whose visibility is tied to the float animation completing).

Use AnimationBehavior.preserve so the controller always runs its full duration, and skip rendering the float animation entirely when animations are disabled.