### PR TITLE
Fix TOT-1115: stop emojis from piling up when app is not in foreground

### DIFF
--- a/packages/totem_core/lib/features/sessions/providers/emoji_reactions_provider.dart
+++ b/packages/totem_core/lib/features/sessions/providers/emoji_reactions_provider.dart
@@ -99,6 +99,20 @@ class EmojiReactions extends _$EmojiReactions {
     state = state
         .map((r) => r == reaction ? r.copyWith(displayed: true) : r)
         .toList();
+
+    // While the app is hidden (e.g. a backgrounded browser tab) no frames
+    // are rendered, so overlay entries would accumulate unbuilt and all
+    // animate at once on refocus. Nobody can see the reaction anyway.
+    final lifecycle = WidgetsBinding.instance.lifecycleState;
+    final isHidden =
+        lifecycle == AppLifecycleState.hidden ||
+        lifecycle == AppLifecycleState.paused ||
+        lifecycle == AppLifecycleState.detached;
+    if (isHidden) {
+      state = state.where((e) => e != reaction).toList();
+      return;
+    }
+
     try {
       await presentEmojiReaction(
         context,

--- a/packages/totem_core/lib/features/sessions/providers/emoji_reactions_provider.dart
+++ b/packages/totem_core/lib/features/sessions/providers/emoji_reactions_provider.dart
@@ -3,6 +3,7 @@ import 'package:flutter/widgets.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:totem_core/features/sessions/widgets/emoji_bar.dart';
+import 'package:totem_core/shared/utils.dart';
 import 'package:uuid/uuid.dart';
 
 part 'emoji_reactions_provider.g.dart';
@@ -96,23 +97,17 @@ class EmojiReactions extends _$EmojiReactions {
     SessionEmojiReaction reaction,
     bool isInListeningTurnScreen,
   ) async {
-    state = state
-        .map((r) => r == reaction ? r.copyWith(displayed: true) : r)
-        .toList();
-
     // While the app is hidden (e.g. a backgrounded browser tab) no frames
     // are rendered, so overlay entries would accumulate unbuilt and all
     // animate at once on refocus. Nobody can see the reaction anyway.
-    final lifecycle = WidgetsBinding.instance.lifecycleState;
-    final isHidden =
-        lifecycle == AppLifecycleState.hidden ||
-        lifecycle == AppLifecycleState.paused ||
-        lifecycle == AppLifecycleState.detached;
-    if (isHidden) {
+    if (isAppHidden()) {
       state = state.where((e) => e != reaction).toList();
       return;
     }
 
+    state = state
+        .map((r) => r == reaction ? r.copyWith(displayed: true) : r)
+        .toList();
     try {
       await presentEmojiReaction(
         context,

--- a/packages/totem_core/lib/features/sessions/widgets/emoji_bar.dart
+++ b/packages/totem_core/lib/features/sessions/widgets/emoji_bar.dart
@@ -175,6 +175,7 @@ Future<void> presentEmojiReaction(
 
   final completer = Completer<void>();
   OverlayEntry? entry;
+  var inserted = false;
 
   try {
     entry = OverlayEntry(
@@ -216,6 +217,7 @@ Future<void> presentEmojiReaction(
     );
 
     overlay.insert(entry!);
+    inserted = true;
     await completer.future.timeout(
       const Duration(seconds: 3),
       onTimeout: () => {},
@@ -227,8 +229,11 @@ Future<void> presentEmojiReaction(
       message: 'Failed to show emoji reaction: $emoji',
     );
   } finally {
-    if (entry?.mounted ?? false) {
-      entry?.remove();
+    // An entry inserted while no frames are rendered (e.g. hidden browser
+    // tab) never mounts, but still sits in the overlay — remove it whenever
+    // it was inserted, not only when it is mounted.
+    if (inserted && entry != null) {
+      entry!.remove();
       entry = null;
     }
   }

--- a/packages/totem_core/lib/shared/utils.dart
+++ b/packages/totem_core/lib/shared/utils.dart
@@ -30,6 +30,16 @@ class SeatsLeftText extends StatelessWidget {
   }
 }
 
+/// Whether the app is currently not rendering frames, e.g. a backgrounded
+/// browser tab or a paused mobile app. Overlay entries inserted in this
+/// state stay unbuilt until the app becomes visible again.
+bool isAppHidden() {
+  final lifecycle = WidgetsBinding.instance.lifecycleState;
+  return lifecycle == AppLifecycleState.hidden ||
+      lifecycle == AppLifecycleState.paused ||
+      lifecycle == AppLifecycleState.detached;
+}
+
 extension WidgetRefExtension on WidgetRef {
   void sentryReportFullyDisplayed<T>(ProviderListenable<T> provider) {
     listen(provider, (old, _) {

--- a/packages/totem_core/lib/shared/widgets/notifications.dart
+++ b/packages/totem_core/lib/shared/widgets/notifications.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/semantics.dart';
 import 'package:totem_core/core/config/theme.dart';
 import 'package:totem_core/shared/totem_icons.dart';
+import 'package:totem_core/shared/utils.dart';
 
 const _defaultNotificationAnimationDuration = Duration(milliseconds: 600);
 const _defaultNotificationDuration = Duration(milliseconds: 2800);
@@ -135,7 +136,10 @@ class NotificationRequest {
       return;
     }
 
-    if (overlayEntry.mounted) {
+    // An entry inserted while no frames were rendered (e.g. a hidden
+    // browser tab) never mounts but still sits in the overlay — remove it
+    // whenever it was inserted, not only when it is mounted.
+    if (_isShown) {
       overlayEntry.remove();
     }
     close();
@@ -277,6 +281,15 @@ class NotificationController {
       },
       onShown: onShown,
     );
+
+    // Timed banners that would present while the app is hidden (e.g. a
+    // backgrounded browser tab) are stale by the time frames render again,
+    // so drop them. Zero-duration banners stay queued so they are still
+    // visible when the app returns to the foreground.
+    if (duration > Duration.zero && isAppHidden()) {
+      request.cancelQueued();
+      return request;
+    }
 
     _enqueue(request);
 

--- a/packages/totem_core/test/features/sessions/providers/emoji_reactions_provider_test.dart
+++ b/packages/totem_core/test/features/sessions/providers/emoji_reactions_provider_test.dart
@@ -184,6 +184,42 @@ void main() {
       expect(find.text('🔥'), findsNothing);
     });
 
+    testWidgets('displayReaction drops the reaction while the app is hidden', (
+      tester,
+    ) async {
+      final container = await pumpOverlayHost(tester);
+      final notifier = container.read(emojiReactionsProvider.notifier);
+
+      await notifier.emitIncomingReaction('user1', '👏');
+      final reaction = container.read(emojiReactionsProvider).first;
+
+      final context = tester.element(
+        find.byKey(EmojiReactions.emojiOverlayKey),
+      );
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      try {
+        await notifier.displayReaction(context, reaction, false);
+
+        expect(
+          container.read(emojiReactionsProvider),
+          isEmpty,
+          reason: 'Hidden app should drop the reaction without presenting it',
+        );
+      } finally {
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+      }
+
+      await tester.pump();
+      expect(
+        find.text('👏'),
+        findsNothing,
+        reason: 'No overlay entry should be queued for when the app resumes',
+      );
+    });
+
     testWidgets('displayReaction renders emoji in not-my-turn mode too', (
       tester,
     ) async {

--- a/packages/totem_core/test/shared/widgets/notifications_test.dart
+++ b/packages/totem_core/test/shared/widgets/notifications_test.dart
@@ -457,6 +457,84 @@ void main() {
     });
   });
 
+  group('hidden app lifecycle', () {
+    testWidgets('dismissActive removes a banner that was never built', (
+      tester,
+    ) async {
+      final context = await pumpHost(tester);
+      final controller = NotificationController();
+
+      final request = controller.showTimed(
+        context,
+        icon: TotemIcons.chat,
+        title: 'Never built',
+        message: 'Dismissed before the first frame',
+      );
+
+      // No pump between show and dismiss: the overlay entry is inserted but
+      // not built yet, like when the tab is hidden and no frames render.
+      request.dismissActive();
+
+      await tester.pump();
+      expect(find.text('Never built'), findsNothing);
+    });
+
+    testWidgets('showTimed drops the banner while the app is hidden', (
+      tester,
+    ) async {
+      final context = await pumpHost(tester);
+      final controller = NotificationController();
+
+      tester.binding.handleAppLifecycleStateChanged(AppLifecycleState.hidden);
+      try {
+        controller.showTimed(
+          context,
+          icon: TotemIcons.chat,
+          title: 'Hidden timed',
+          message: 'Stale by the time the app is visible again',
+        );
+      } finally {
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.resumed,
+        );
+      }
+
+      await tester.pump();
+      expect(find.text('Hidden timed'), findsNothing);
+    });
+
+    testWidgets(
+      'showPermanent while hidden is still visible when the app returns',
+      (tester) async {
+        final context = await pumpHost(tester);
+        final controller = NotificationController();
+
+        tester.binding.handleAppLifecycleStateChanged(
+          AppLifecycleState.hidden,
+        );
+        try {
+          controller.showPermanent(
+            context,
+            icon: TotemIcons.pause,
+            title: 'Hidden permanent',
+            message: 'Should survive until the app is visible again',
+          );
+        } finally {
+          tester.binding.handleAppLifecycleStateChanged(
+            AppLifecycleState.resumed,
+          );
+        }
+
+        await tester.pump();
+        expect(find.text('Hidden permanent'), findsOneWidget);
+
+        controller.dismissAll();
+        await tester.pumpAndSettle();
+        expect(find.text('Hidden permanent'), findsNothing);
+      },
+    );
+  });
+
   group('semantics announcements', () {
     testWidgets('showTimed announces message', (tester) async {
       final context = await pumpHost(tester);


### PR DESCRIPTION
Fixed a few other animations that would have this issue on the Rooms screens as well (notifications).